### PR TITLE
Fix processing count in update_stats

### DIFF
--- a/lib/Monoceros/Server.pm
+++ b/lib/Monoceros/Server.pm
@@ -234,7 +234,7 @@ my $prev_stats = '';
 sub update_stats {
     my $self = shift;
     my $total = scalar keys %{$self->{sockets}};
-    my $processing = scalar grep { !$self->{sockets}{$_}[S_STATE] == 1 } keys %{$self->{sockets}};
+    my $processing = scalar grep { $self->{sockets}{$_}[S_STATE] == 1 } keys %{$self->{sockets}};
     my $idle = scalar grep { $self->{sockets}{$_}[S_STATE] == 0 } keys %{$self->{sockets}};
 
     my $stats = "total=$total&";


### PR DESCRIPTION
Previously, update_stats() would use the idle count for both `waiting` and `processing`.

Error found by perl 5.42:

    Possible precedence problem between ! and numeric eq (==) at .../Monoceros/Server.pm line 237.